### PR TITLE
Fix empty content file

### DIFF
--- a/components/ContentEditor.php
+++ b/components/ContentEditor.php
@@ -1,7 +1,7 @@
 <?php namespace Samuell\ContentEditor\Components;
 
+use File;
 use BackendAuth;
-
 use Cms\Classes\Content;
 use Cms\Classes\CmsObject;
 use Cms\Classes\ComponentBase;
@@ -123,7 +123,7 @@ class ContentEditor extends ComponentBase
 
         // Compability with Rainlab.StaticPage
         // StaticPages content does not append default locale to file.
-        if ($this->isStaticPage() && $locale === $defaultLocale) {
+        if ($this->fileExists($file) && $locale === $defaultLocale) {
           return $file;
         }
 
@@ -136,13 +136,12 @@ class ContentEditor extends ComponentBase
         return $backendUser && $backendUser->hasAccess(Settings::get('permissions', 'cms.manage_content'));
     }
 
+    public function fileExists($file) {
+        return File::exists((new Content)->getFilePath($file));
+    }
+
     public function translateExists()
     {
         return class_exists('\RainLab\Translate\Classes\Translator');
-    }
-
-    public function isStaticPage()
-    {
-        return isset($this->getPage()->apiBag['staticPage']);
     }
 }


### PR DESCRIPTION
I've fixed a bug that when you create Content Blocks from the StaticPage plugin and create a CMS Page, when on the default locale, the component would look for the Content Block with the appended locale. 

This resulted in having empty Content Blocks (since the the StaticPage plugin Content Block doesn't append default locale to the files). The reverse was also the same, if you created Content Block from the CMS with the appended locale, StaticPage page wouldn't find the file and return empty Content Block.

I've changed the behavior of the conditions. So basically I've replaced the StaticPage condition for a File exists conditions. So the final behaviour has become when you're on the default locale, it checks if the file exists without the appended locales, otherwise append the locale like usual.

