### PR TITLE
Show settings  tools as default && If no translation file - use default

### DIFF
--- a/assets/contenteditor.js
+++ b/assets/contenteditor.js
@@ -39,7 +39,17 @@ editor.addEventListener('saved', function (ev) {
 */
 ContentEdit.Root.get().bind('focus', function(element) {
     var dataTools = element._parent._domElement.dataset.tools
-    var tools = (dataTools === '*' ? ContentTools.DEFAULT_TOOLS : [element._parent._domElement.dataset.tools.split(',')]);
+    var tools;
+    switch (dataTools) {
+        case '':
+            tools = editor._toolbox._tools;
+            break;
+        case '*':
+            tools = ContentTools.DEFAULT_TOOLS;
+            break;
+        default: 
+            tools = [element._parent._domElement.dataset.tools.split(',')];
+    }
     if (element.isFixed()) tools = dataTools !== '*' ? tools : [['undo', 'redo', 'remove']];
     if (editor.toolbox().tools() !== tools) editor.toolbox().tools(tools);
 });

--- a/components/ContentEditor.php
+++ b/components/ContentEditor.php
@@ -41,7 +41,7 @@ class ContentEditor extends ComponentBase
             'tools' => [
                 'title'       => 'List of enabled tools',
                 'description' => 'List of enabled tools for selected content (for all use *)',
-                'default'     => '*',
+                'default'     => '',
             ]
         ];
     }
@@ -72,15 +72,18 @@ class ContentEditor extends ComponentBase
         $this->tools = $this->property('tools');
 
         if ($this->checkEditor()) {
-
+            // if no locale file exists -> render the default, without language suffix
             if (Content::load($this->getTheme(), $this->file)){
                 $this->content = $this->renderContent($this->file);
             } else {
-                $this->content = '';
+                $this->content = $this->renderContent($this->property('file'));
             }
-
         } else {
-            return $this->renderContent($this->file);
+            if (Content::load($this->getTheme(), $this->file)){
+                return $this->renderContent($this->file);
+            } else {
+                return $this->renderContent($this->property('file'));
+            }
         }
     }
 


### PR DESCRIPTION
Hey.
I've switched with the changes to the new release. They are as follows: 
 
1.
When "tools" attribute is empty or not specified in

`{% component 'contenteditor' tools="*" file="foo.htm" %}`

make user-selected tools available (chosen in Backend->Settings->Content Editor Settings).

Currently all ('*') tools are available.

2. 
If no RainLab.Translate locale file for the current language exists, use the default file content, eg.:

if no` content/foo.pl.htm` -> use `content/foo.htm` content.
After saving - `content/foo.pl.htm` will be created.

Makes the translation process easier for the user (field is not empty, but populated with default text) and prevents ugly October error if no locale file exists and the user is logged out.