### PR TITLE
Additional styles shows multiple times

### DIFF
--- a/components/ContentEditor.php
+++ b/components/ContentEditor.php
@@ -73,7 +73,7 @@ class ContentEditor extends ComponentBase
     public function onRender()
     {
         $this->additional_styles = Settings::renderCss();
-        $this->renderCount += 1;
+        $this->renderCount = $this->page['renderCount'] += 1;
 
         $this->file = $this->setFile($this->property('file'));
         $this->fixture = $this->property('fixture');


### PR DESCRIPTION
When I add additional styles, like an align justify, it shows one time per component call, even with aliases, so this fixes this showing only once the rule you want to apply.

Before
![2018-06-28_11h15_11](https://user-images.githubusercontent.com/11737272/42025352-a72cacd8-7ac4-11e8-8047-d73d99f8e39b.png)
After
![2018-06-28_11h15_38](https://user-images.githubusercontent.com/11737272/42025363-abf44b5e-7ac4-11e8-9c6a-0dafb872b00e.png)
