### PR TITLE
Fix discarding of CSS class when defined in file but saved via CMS

### DIFF
--- a/components/ContentEditor.php
+++ b/components/ContentEditor.php
@@ -50,6 +50,11 @@ class ContentEditor extends ComponentBase
                 'description' => 'List of enabled tools for selected content (for all use *)',
                 'default'     => ''
             ],
+            'class' => [
+                'title'       => 'CSS classes',
+                'description' => 'CSS class or classes that should be applied to the content block when rendered',
+                'default'     => ''
+            ],
         ];
     }
 


### PR DESCRIPTION
With #57 a new feature was added to support classes for a fixture element. 

While using this useful feature, I found a bug that removes the `class` property when a file is saved via CMS since `class` is not defined in the component properties and therefore discarded when saved. 

This pull-request should fix this bug since it adds the missing `class` property to the list of the ContentEditor component properties.