### PR TITLE
Call ContentTools.StylePalette and styles only once

### DIFF
--- a/components/ContentEditor.php
+++ b/components/ContentEditor.php
@@ -74,6 +74,9 @@ class ContentEditor extends ComponentBase
             $this->addJs('assets/content-tools.min.js');
             $this->addJs('assets/contenteditor.js');
         }
+
+        // Add scripts only once
+        $this->renderPartial('@scripts.htm');
     }
 
     public function onRender()

--- a/components/contenteditor/default.htm
+++ b/components/contenteditor/default.htm
@@ -6,32 +6,3 @@
     {% if __SELF__.class %}class="{{ __SELF__.class }}"{% endif %}>
     {{ __SELF__.content|raw }}
 </{% if __SELF__.fixture %}{{ __SELF__.fixture }}{% else %}div{% endif %}>
-
-{% if __SELF__.renderCount == 1 %}
-    {% put scripts %}
-    <script type="text/javascript">
-    /* CONTENT EDITOR SCRIPT START */
-    ContentTools.StylePalette.add([
-        {% for style in __SELF__.palettes %}
-            new ContentTools.Style('{{ style.name ? style.name : style.class }}', '{{ style.class }}', {{ style.allowed_tags|json_encode()|raw }}),
-        {% endfor %}
-    ]);
-    editor.toolbox().tools([
-                                [
-                                {% for value in __SELF__.buttons %}
-                                    '{{ value }}',
-                                {% endfor %}
-                                ],
-                                [
-                                    'undo',
-                                    'redo',
-                                    'remove'
-                                ]
-                            ]);
-    /* CONTENT EDITOR SCRIPT END */
-    </script>
-    {% endput %}
-    {% put styles  %}
-        <link rel="stylesheet" href="/contenteditor/styles">
-    {% endput %}
-{% endif %}

--- a/components/contenteditor/scripts.htm
+++ b/components/contenteditor/scripts.htm
@@ -1,0 +1,26 @@
+{% put scripts %}
+    <script type="text/javascript">
+    /* CONTENT EDITOR SCRIPT START */
+    ContentTools.StylePalette.add([
+        {% for style in __SELF__.palettes %}
+            new ContentTools.Style('{{ style.name ? style.name : style.class }}', '{{ style.class }}', {{ style.allowed_tags|json_encode()|raw }}),
+        {% endfor %}
+    ]);
+    editor.toolbox().tools([
+                                [
+                                {% for value in __SELF__.buttons %}
+                                    '{{ value }}',
+                                {% endfor %}
+                                ],
+                                [
+                                    'undo',
+                                    'redo',
+                                    'remove'
+                                ]
+                            ]);
+    /* CONTENT EDITOR SCRIPT END */
+    </script>
+{% endput %}
+{% put styles  %}
+    <link rel="stylesheet" href="/contenteditor/styles">
+{% endput %}


### PR DESCRIPTION
This PR fix the issue where StylePalette is injected multiple times when you have several contenteditor blocks in your pages, partials etc.... See [This issue](https://github.com/Samuell1/contenteditor-plugin/issues/81#issuecomment-1164179809)