### PR TITLE
Fixed a bug that the style palettes were not being loaded due an incorrect DOM event

### DIFF
--- a/components/contenteditor/scripts.htm
+++ b/components/contenteditor/scripts.htm
@@ -1,7 +1,7 @@
 {% put scripts %}
     <script type="text/javascript">
         /* CONTENT EDITOR SCRIPT START */
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener(oc.useTurbo ? 'page:loaded' : 'DOMContentLoaded', function() {
             ContentTools.StylePalette.add([
                 {% for style in __SELF__.palettes %}
                     new ContentTools.Style('{{ style.name ? style.name : style.class }}', '{{ style.class }}', {{ style.allowed_tags|json_encode()|raw }}),

--- a/components/contenteditor/scripts.htm
+++ b/components/contenteditor/scripts.htm
@@ -1,7 +1,7 @@
 {% put scripts %}
     <script type="text/javascript">
         /* CONTENT EDITOR SCRIPT START */
-        document.addEventListener('page:loaded', function() {
+        document.addEventListener('DOMContentLoaded', function() {
             ContentTools.StylePalette.add([
                 {% for style in __SELF__.palettes %}
                     new ContentTools.Style('{{ style.name ? style.name : style.class }}', '{{ style.class }}', {{ style.allowed_tags|json_encode()|raw }}),


### PR DESCRIPTION
Fixed a bug that the custom style palettes were not being loaded on the front-end.  Swapped the page:loaded event for DOMContentLoaded because page:loaded is a custom event. Now the custom style palettes are being loaded correctly.
