### PR TITLE
Push small change to master

### DIFF
--- a/components/contenteditor/scripts.htm
+++ b/components/contenteditor/scripts.htm
@@ -1,7 +1,7 @@
 {% put scripts %}
     <script type="text/javascript">
         /* CONTENT EDITOR SCRIPT START */
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener(oc.useTurbo ? 'page:loaded' : 'DOMContentLoaded', function() {
             ContentTools.StylePalette.add([
                 {% for style in __SELF__.palettes %}
                     new ContentTools.Style('{{ style.name ? style.name : style.class }}', '{{ style.class }}', {{ style.allowed_tags|json_encode()|raw }}),

--- a/components/contenteditor/scripts.htm
+++ b/components/contenteditor/scripts.htm
@@ -1,7 +1,7 @@
 {% put scripts %}
     <script type="text/javascript">
         /* CONTENT EDITOR SCRIPT START */
-        document.addEventListener('page:loaded', function() {
+        document.addEventListener('DOMContentLoaded', function() {
             ContentTools.StylePalette.add([
                 {% for style in __SELF__.palettes %}
                     new ContentTools.Style('{{ style.name ? style.name : style.class }}', '{{ style.class }}', {{ style.allowed_tags|json_encode()|raw }}),


### PR DESCRIPTION
This pull request includes a change to the `components/contenteditor/scripts.htm` file to improve the handling of page load events in the content editor script.

* Modified the event listener to check for `oc.useTurbo` and use either 'page:loaded' or 'DOMContentLoaded' accordingly.